### PR TITLE
Fix incorrect heap stats

### DIFF
--- a/src/heap.c
+++ b/src/heap.c
@@ -314,7 +314,7 @@ static bool _mi_heap_page_destroy(mi_heap_t* heap, mi_page_queue_t* pq, mi_page_
   }
   mi_heap_stat_decrease(heap, malloc, bsize * inuse);  // todo: off for aligned blocks...
 #endif
-  heap->allocated -= page->used * mi_page_usable_block_size(page);
+  heap->allocated -= inuse * mi_page_usable_block_size(page);
 
   /// pretend it is all free now
   mi_assert_internal(mi_page_thread_free(page) == NULL);

--- a/src/stats.c
+++ b/src/stats.c
@@ -415,8 +415,12 @@ void mi_thread_stats_print_out(mi_output_fun* out, void* arg) mi_attr_noexcept {
 
 void mi_thread_stats(int64_t *allocated, int64_t *committed) mi_attr_noexcept {
   mi_heap_t *heap = mi_heap_get_default();
-  *committed = heap->committed;
-  *allocated = heap->allocated;
+  if (mi_likely(committed)) {
+    *committed = heap->committed;
+  }
+  if (mi_likely(allocated)) {
+    *allocated = heap->allocated;
+  }
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
1. Update heap stats on page abandon and reclaim.
2. Do not count in segment info into heap stats.